### PR TITLE
Extra tests and a number of minor bug fixes

### DIFF
--- a/lib/Devel/PartialDump.pm
+++ b/lib/Devel/PartialDump.pm
@@ -291,6 +291,7 @@ sub format_array {
 	my ( $self, $depth, $array ) = @_;
 
 	my $class = blessed($array) || '';
+	$class .= "=" if $class;
 
 	return $class . "[ " . $self->dump_as_list($depth + 1, @$array) . " ]";
 }
@@ -299,6 +300,7 @@ sub format_hash {
 	my ( $self, $depth, $hash ) = @_;
 
 	my $class = blessed($hash) || '';
+	$class .= "=" if $class;
 
 	return $class . "{ " . $self->dump_as_pairs($depth + 1, map { $_ => $hash->{$_} } sort keys %$hash) . " }";
 }

--- a/lib/Devel/PartialDump.pm
+++ b/lib/Devel/PartialDump.pm
@@ -185,10 +185,10 @@ sub dump {
 
 	my $dump = $self->$method(1, @args);
 
-	if ( $self->has_max_length ) {
-		if ( length($dump) > $self->max_length ) {
-			$dump = substr($dump, 0, $self->max_length - 3) . "...";
-		}
+	if ( $self->has_max_length and length($dump) > $self->max_length ) {
+		my $max_length = $self->max_length - 3;
+		$max_length = 0 if $max_length < 0;
+		substr( $dump, $max_length, length($dump) - $max_length, '...' );
 	}
 
 	if ( not defined wantarray ) {
@@ -228,7 +228,7 @@ sub _dump_as_pairs {
 	my ( $self, $depth, @what ) = @_;
 
 	return unless @what;
-	
+
 	my ( $key, $value, @rest ) = @what;
 
 	return (

--- a/lib/Devel/PartialDump.pm
+++ b/lib/Devel/PartialDump.pm
@@ -221,7 +221,7 @@ sub dump_as_pairs {
 		@what = splice(@what, 0, $self->max_elements * 2 );
 	}
 
-	return join($self->list_delim, $self->_dump_as_pairs($depth, @what), ($truncated ? "..." : ()) );
+	return join( $self->list_delim, $self->_dump_as_pairs($depth, @what), ($truncated ? "..." : ()) );
 }
 
 sub _dump_as_pairs {
@@ -246,7 +246,7 @@ sub dump_as_list {
 		@what = splice(@what, 0, $self->max_elements );
 	}
 
-	return join( ", ", ( map { $self->format($depth, $_) } @what ), ($truncated ? "..." : ()) );
+	return join( $self->list_delim, ( map { $self->format($depth, $_) } @what ), ($truncated ? "..." : ()) );
 }
 
 sub format {

--- a/t/basic.t
+++ b/t/basic.t
@@ -15,10 +15,6 @@ is( $d->dump("foo" => "bar"), 'foo: "bar"', "named params" );
 
 is( $d->dump( foo => "bar", gorch => [ 1, "bah" ] ), 'foo: "bar", gorch: [ 1, "bah" ]', "recursion" );
 
-like( $d->dump( [ { foo => ["bar"] } ] ), qr/\[ \{ foo: ARRAY\(0x[a-z0-9]+\) \} \]/i, "max depth" );
-
-is( $d->dump([ 1 .. 10 ]), '[ 1, 2, 3, 4, 5, 6, ... ]', "max elements" );
-
 is( $d->dump("foo\nbar"), '"foo\nbar"', "newline" );
 
 is( $d->dump("foo" . chr(1)), '"foo\x{1}"', "non printable" );

--- a/t/basic.t
+++ b/t/basic.t
@@ -11,7 +11,11 @@ my $d = Devel::PartialDump->new;
 
 is( $d->dump("foo"), '"foo"', "simple value" );
 
+is( $d->dump(undef), "undef", "undef" );
+
 is( $d->dump("foo" => "bar"), 'foo: "bar"', "named params" );
+
+is( $d->dump( \"foo" => "bar" ), '\\"foo", "bar"', "not named params" );
 
 is( $d->dump( foo => "bar", gorch => [ 1, "bah" ] ), 'foo: "bar", gorch: [ 1, "bah" ]', "recursion" );
 

--- a/t/delim.t
+++ b/t/delim.t
@@ -1,0 +1,24 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use constant CLASS => 'Devel::PartialDump';
+
+use ok CLASS;
+
+my $d = new_ok CLASS;
+
+$d->pairs(0);
+$d->list_delim(",");
+
+is( $d->dump("foo", "bar"), '"foo","bar"', "list_delim" );
+
+$d->pairs(1);
+$d->pair_delim("=>");
+
+is( $d->dump("foo" => "bar"), 'foo=>"bar"', "pair_delim" );
+
+done_testing;

--- a/t/max.t
+++ b/t/max.t
@@ -1,0 +1,91 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use constant CLASS => 'Devel::PartialDump';
+
+use ok CLASS;
+
+# -----------------
+# max_length
+
+my @list = 1 .. 10;
+
+my $d = CLASS->new;
+$d->pairs(0);
+$d->clear_max_elements;
+
+$d->clear_max_length;
+is( $d->dump(@list), '1, 2, 3, 4, 5, 6, 7, 8, 9, 10', 'max_length undefined' );
+
+$d->max_length(100);
+is( $d->dump(@list), '1, 2, 3, 4, 5, 6, 7, 8, 9, 10', 'max_length high' );
+
+$d->max_length(10);
+is( $d->dump(@list), '1, 2, 3...', 'max_length low' );
+
+$d->max_length(0);
+is( $d->dump(@list), '...', 'max_length zero' );
+
+# -----------------
+# max_elements
+
+$d = CLASS->new;
+
+$d->pairs(0);
+{
+    $d->clear_max_elements;
+    is( $d->dump(@list), '1, 2, 3, 4, 5, 6, 7, 8, 9, 10',
+        'list max_elements undefined' );
+
+    $d->max_elements(100);
+    is( $d->dump(@list), '1, 2, 3, 4, 5, 6, 7, 8, 9, 10',
+        'list max_elements high' );
+
+    $d->max_elements(6);
+    is( $d->dump(@list), '1, 2, 3, 4, 5, 6, ...',
+        'list max_elements low' );
+
+    $d->max_elements(0);
+    is( $d->dump(@list), '...', 'list max elements zero' );
+}
+
+$d->pairs(1);
+{
+    $d->clear_max_elements;
+    is( $d->dump(@list), '1: 2, 3: 4, 5: 6, 7: 8, 9: 10',
+        'pairs max_elements undefined' );
+
+    $d->max_elements(100);
+    is( $d->dump(@list), '1: 2, 3: 4, 5: 6, 7: 8, 9: 10',
+        'pairs max_elements high' );
+
+    $d->max_elements(3);
+    is( $d->dump(@list), '1: 2, 3: 4, 5: 6, ...',
+        'pairs max_elements low' );
+
+    $d->max_elements(0);
+    is( $d->dump(@list), '...', 'pairs max elements zero' );
+}
+
+# -----------------
+# max_depth
+
+$d = CLASS->new;
+
+$d->max_depth(10);
+is( $d->dump( [ { foo => ["bar"] } ] ),
+    '[ { foo: [ "bar" ] } ]', 'max_depth high' );
+
+$d->max_depth(2);
+like( $d->dump( [ { foo => ["bar"] } ] ),
+    qr/^\[ \{ foo: ARRAY\(0x[a-z0-9]+\) \} \]$/, 'max_depth low' );
+
+$d->max_depth(0);
+like( $d->dump( [ { foo => ["bar"] } ] ),
+    qr/^ARRAY\(0x[a-z0-9]+\)$/, 'max_depth zero' );
+
+done_testing;

--- a/t/objects.t
+++ b/t/objects.t
@@ -1,0 +1,72 @@
+#!/usr/bin/perl -T
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use constant CLASS => 'Devel::PartialDump';
+
+use ok CLASS;
+
+package My::Object::Hash;
+{
+    use overload '""' => \&stringify;
+
+    sub new {
+        my $class = shift;
+        bless { value => $_[0] }, $class;
+    }
+    sub stringify { $_[0]->{value} }
+}
+
+package My::Object::Array;
+{
+    use overload '""' => \&stringify;
+
+    sub new {
+        my $class = shift;
+        bless [$_[0]], $class;
+    }
+    sub stringify { $_[0]->[0] }
+}
+
+package My::Object::Scalar;
+{
+    use overload '""' => \&stringify;
+
+    sub new {
+        my $class = shift;
+        bless \$_[0], $class;
+    }
+    sub stringify { ${$_[0]} }
+}
+
+package main;
+
+my $hash = My::Object::Hash->new('foo');
+my $array = My::Object::Array->new('foo');
+my $scalar = My::Object::Scalar->new('foo');
+
+my $d = new_ok CLASS;
+
+is( $d->dump($hash), 'My::Object::Hash={ value: "foo" }', 'hash object dump' );
+is( $d->dump($array), 'My::Object::Array=[ "foo" ]', 'array object dump' );
+is( $d->dump($scalar), 'My::Object::Scalar=\"foo"', 'scalar object dump' );
+
+$d = CLASS->new( objects => 0 );
+
+like( $d->dump($hash), qr/^My::Object::Hash=HASH\(0x[a-z0-9]+\)$/,
+    'hash object stringified' );
+like( $d->dump($array), qr/^My::Object::Array=ARRAY\(0x[a-z0-9]+\)$/,
+    'array object stringified' );
+like( $d->dump($scalar), qr/^My::Object::Scalar=SCALAR\(0x[a-z0-9]+\)$/,
+    'scalar object stringified' );
+
+$d = CLASS->new( objects => 0, stringify => 1 );
+
+is( $d->dump($hash), 'foo', 'hash object string overloaded' );
+is( $d->dump($array), 'foo', 'array object string overloaded' );
+is( $d->dump($scalar), 'foo', 'scalar object string overloaded' );
+
+done_testing;


### PR DESCRIPTION
I added extra tests to exercise more of the code. In doing so, I found a number of minor bugs which I have also fixed. These bugs include:
1. Setting attribute `list_delim` does not affect list dumps because it was not being used to separate list elements in `dump_as_list()`.
2. Setting attribute `max_length` as 0 doesn't shorten dumps as much as it should. I've made it so that max_length 0 results in `...`.
3. Object dumps for scalar ref objects appear as `Object::Name=\"scalar"`, but for array/hash ref objects, the `=` is missing. I've added the `=` so they are consistent.
